### PR TITLE
docs(datasource): Add additional examples for custom datasource

### DIFF
--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -82,7 +82,7 @@ All available options:
 
 ## Examples
 
-# K3s
+### K3s
 
 You can use this configuration to request the newest version available to [K3s](https://k3s.io/)
 
@@ -96,5 +96,93 @@ You can use this configuration to request the newest version available to [K3s](
       ],
     },
   },
+}
+```
+
+### Hashicorp
+
+You can use this configuration to request the newest versions of the hashicorp products:
+
+```json
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.yml$"],
+      "datasourceTemplate": "custom.hashicorp",
+      "matchStrings": [
+        "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*\\w*:\\s*(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "customDatasources": {
+    "hashicorp": {
+      "defaultRegistryUrlTemplate": "https://api.releases.hashicorp.com/v1/releases/{{packageName}}?license_class=oss",
+      "transformTemplates": [
+        "{ \"releases\": $map($, function($v) { { \"version\": $v.version, \"releaseTimestamp\": $v.timestamp_created, \"changelogUrl\": $v.url_changelog, \"sourceUrl\": $v.url_source_repository } }), \"homepage\": $[0].url_project_website, \"sourceUrl\": $[0].url_source_repository }"
+      ]
+    }
+  },
+}
+```
+
+E.g. to have the latest Nomad version in your ansible variables, use this snippet after adding the above configuration:
+
+```yaml
+# renovate: depName=nomad
+nomad_version: 1.6.0
+```
+
+### Custom Offline Dependencies
+
+Sometimes the source of the dependency versions is not available via an API but has to be generated manually. For this purpose, you can manually create dependency "files" (similar to an API) served via http(s) for renovate to access. For example, imagine the following file `versiontracker.json` for the software `something``:
+
+```json
+[
+    {
+        "version": "77"
+    },
+    {
+        "version": "76"
+    },
+]
+```
+
+Which can be ingested by renovate using the following custom datasource (using nexus as a webserver in this case):
+
+```json
+{
+  "customDatasources": {
+    "nexus_generic": {
+      "defaultRegistryUrlTemplate": "https://nexus.example.com/repository/versiontrackers/{{packageName}}/versiontracker.json",
+      "transformTemplates": [
+        "{ \"releases\": $map($, function($v) { { \"version\": $v.version, \"sourceUrl\": $v.filelink } }) }"
+      ]
+    }
+  },
+}
+```
+
+This could be used to update ansible yaml files with the latest version through a regex manager, e.g. with the following ansible content:
+
+```yaml
+# renovate: datasource=custom.nexus_generic depName=something versioning=loose
+something_version: "77"
+```
+
+And the following regex manager:
+
+```json
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.yml$"],
+      "datasourceTemplate": "custom.nexus_generic",
+      "matchStrings": [
+        "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*\\w*:\\s*\"?(?<currentValue>.+?)\"?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
 }
 ```


### PR DESCRIPTION
## Changes

Added the examples for hashicorp and offline dependencies for the custom datasource

## Context

Following the request of a maintainer [here](https://github.com/renovatebot/renovate/discussions/23286#discussioncomment-6496671).

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
